### PR TITLE
Add torch imports to modules

### DIFF
--- a/Blanchot-Guided Activation Function.py
+++ b/Blanchot-Guided Activation Function.py
@@ -1,3 +1,5 @@
+import torch
+
 def blanchot_activation(x, epsilon=1e-6):
     """
     A Blanchot-inspired activation function where thresholds exist

--- a/BlanchotianEmbedding.py
+++ b/BlanchotianEmbedding.py
@@ -1,3 +1,7 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
 class BlanchotianEmbedding(nn.Module):
     def __init__(self, num_tokens, dim, orpheus_factor=0.1):
         super().__init__()


### PR DESCRIPTION
## Summary
- add missing torch imports in Blanchot-Guided Activation Function
- add torch and nn imports before class definition in BlanchotianEmbedding

## Testing
- `python -m py_compile *.py`