### PR TITLE
Add unit tests for loss and attention modules

### DIFF
--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,0 +1,29 @@
+import importlib.machinery
+import importlib.util
+import torch
+
+# Dynamically load the module with a space in the filename
+module_name = "blanchotian_attention"
+file_path = "Blanchotian Attention Mechanism.py"
+loader = importlib.machinery.SourceFileLoader(module_name, file_path)
+spec = importlib.util.spec_from_loader(module_name, loader)
+attention_module = importlib.util.module_from_spec(spec)
+loader.exec_module(attention_module)
+
+BlanchotianAttention = attention_module.BlanchotianAttention
+
+
+def test_attention_forward_pass_output_shape():
+    attn = BlanchotianAttention(dim=16, heads=4)
+    x = torch.randn(2, 5, 16)
+    out = attn(x)
+    assert out.shape == x.shape
+
+
+def test_attention_trace_updates():
+    attn = BlanchotianAttention(dim=8, heads=2)
+    x = torch.randn(1, 3, 8)
+    initial_trace = attn.attention_trace.clone()
+    _ = attn(x)
+    updated_trace = attn.attention_trace
+    assert not torch.allclose(initial_trace, updated_trace)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,36 @@
+import torch
+import pytest
+
+import importlib
+import types
+
+# directly import blanchot_neutral_loss from losses.py
+from losses import blanchot_neutral_loss
+
+
+def test_blanchot_neutral_loss_output_shape_mean():
+    logits = torch.randn(4, 10)
+    targets = torch.randint(0, 10, (4,))
+    loss = blanchot_neutral_loss(logits, targets, reduction="mean")
+    assert loss.dim() == 0
+
+
+def test_blanchot_neutral_loss_output_shape_none():
+    logits = torch.randn(5, 7)
+    targets = torch.randint(0, 7, (5,))
+    loss = blanchot_neutral_loss(logits, targets, reduction="none")
+    assert loss.shape == torch.Size([5])
+
+
+def test_blanchot_neutral_loss_invalid_logits_dim():
+    logits = torch.randn(2, 3, 4)
+    targets = torch.randint(0, 4, (2,))
+    with pytest.raises(ValueError):
+        blanchot_neutral_loss(logits, targets)
+
+
+def test_blanchot_neutral_loss_invalid_reduction():
+    logits = torch.randn(3, 4)
+    targets = torch.randint(0, 4, (3,))
+    with pytest.raises(ValueError):
+        blanchot_neutral_loss(logits, targets, reduction="avg")


### PR DESCRIPTION
## Summary
- add new `tests` directory
- test `blanchot_neutral_loss` output shapes and error handling
- add tests for `Blanchotian Attention Mechanism` forward pass and trace update

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*