### PR TITLE
Fix README file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 | Component | Essence | File |
 |-----------|---------|------|
-| **Blanchotian Attention** | Each token attends to tokens‑present **and** to the very *lack* of attention it once gave.  Includes learnable void Q/K vectors and a decaying trace of past attention. | `attention.py` |
-| **Orphic Embeddings** | Tokens are shaped by what surrounds them and what is forever hidden.  Rarity gates, isolation vectors, contextual inversion. | `embeddings.py` |
+| **Blanchotian Attention** | Each token attends to tokens‑present **and** to the very *lack* of attention it once gave.  Includes learnable void Q/K vectors and a decaying trace of past attention. | `Blanchotian Attention Mechanism.py` |
+| **Orphic Embeddings** | Tokens are shaped by what surrounds them and what is forever hidden.  Rarity gates, isolation vectors, contextual inversion. | `OrphicEmbeddings.py` |
 | **Neutral Loss** | Re‑centres error as a creative differential; stable log‑sum‑exp, label smoothing, disaster threshold. | `losses.py` |
-| **Blanchotian Transformer** | Layers commune with **all** preceding layers—an endless palimpsest. | `transformer.py` |
-| **Unavowable Community** | Ensemble whose disagreement is the signal; models converse through divergence. | `community.py` |
+| **Blanchotian Transformer** | Layers commune with **all** preceding layers—an endless palimpsest. | `The Infinite Conversation.py` |
+| **Unavowable Community** | Ensemble whose disagreement is the signal; models converse through divergence. | `Unavowable Community.py` |
 
 ---
 


### PR DESCRIPTION
## Summary
- update table links in README to match actual filenames

## Testing
- `python -m py_compile *.py`