### PR TITLE
Add void attention visualization tool

### DIFF
--- a/Blanchotian Attention Mechanism.py
+++ b/Blanchotian Attention Mechanism.py
@@ -23,7 +23,7 @@ class BlanchotianAttention(nn.Module):
         # Temperature adjustment parameter
         self.temperature_factor = nn.Parameter(torch.ones(heads, 1, 1))
 
-    def forward(self, x):
+    def forward(self, x, *, return_attention: bool = False):
         b, n, _ = x.shape
         
         # Project input to queries, keys, values
@@ -66,4 +66,8 @@ class BlanchotianAttention(nn.Module):
         
         # Rearrange and project
         out = rearrange(out, 'b h n d -> b n (h d)')
-        return self.to_out(out)
+        out = self.to_out(out)
+
+        if return_attention:
+            return out, attn
+        return out

--- a/Void Attention Visualizer.py
+++ b/Void Attention Visualizer.py
@@ -1,0 +1,59 @@
+import torch
+from typing import List, Optional
+import matplotlib.pyplot as plt
+
+import importlib.machinery
+import importlib.util
+
+# Dynamically load BlanchotianAttention from the file with spaces
+_module_name = "blanchotian_attention"
+_loader = importlib.machinery.SourceFileLoader(
+    _module_name, "Blanchotian Attention Mechanism.py")
+_spec = importlib.util.spec_from_loader(_module_name, _loader)
+_attn_module = importlib.util.module_from_spec(_spec)
+_loader.exec_module(_attn_module)
+
+BlanchotianAttention = _attn_module.BlanchotianAttention
+
+def plot_void_attention(
+    attn: BlanchotianAttention,
+    x: torch.Tensor,
+    token_labels: Optional[List[str]] = None,
+    *,
+    head: int = 0,
+):
+    """Plot attention including the void token.
+
+    Parameters
+    ----------
+    attn : BlanchotianAttention
+        Attention module instance.
+    x : torch.Tensor
+        Input of shape ``(B, N, D)``.
+    token_labels : list[str] | None
+        Optional labels for the ``N`` tokens and the void token.
+    head : int
+        Which head to visualise.
+    """
+    attn.eval()
+    with torch.no_grad():
+        _, attn_weights = attn(x, return_attention=True)
+
+    # attn_weights: (B, H, N+1, N+1)
+    attn_avg = attn_weights.mean(dim=0)[head]
+    n = x.shape[1]
+    labels = token_labels or [f"t{i}" for i in range(n)] + ["<void>"]
+    if len(labels) != n + 1:
+        raise ValueError("token_labels must have length N + 1")
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(attn_avg.cpu().numpy(), cmap="viridis", interpolation="nearest")
+    ax.set_xticks(range(n + 1))
+    ax.set_yticks(range(n + 1))
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    ax.set_yticklabels(labels)
+    ax.set_xlabel("Key")
+    ax.set_ylabel("Query")
+    fig.colorbar(im, ax=ax)
+    fig.tight_layout()
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch
 einops
+matplotlib

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,24 @@
+import importlib.machinery
+import importlib.util
+import torch
+
+loader = importlib.machinery.SourceFileLoader(
+    "visualizer", "Void Attention Visualizer.py")
+spec = importlib.util.spec_from_loader("visualizer", loader)
+vis_module = importlib.util.module_from_spec(spec)
+loader.exec_module(vis_module)
+
+loader_attn = importlib.machinery.SourceFileLoader(
+    "blanchotian_attention", "Blanchotian Attention Mechanism.py")
+spec_attn = importlib.util.spec_from_loader("blanchotian_attention", loader_attn)
+attn_module = importlib.util.module_from_spec(spec_attn)
+loader_attn.exec_module(attn_module)
+
+BlanchotianAttention = attn_module.BlanchotianAttention
+
+
+def test_plot_void_attention_runs():
+    attn = BlanchotianAttention(dim=8, heads=2)
+    x = torch.randn(1, 3, 8)
+    fig = vis_module.plot_void_attention(attn, x, head=0)
+    assert hasattr(fig, "axes")


### PR DESCRIPTION
## Summary
- add an optional return of attention weights in `Blanchotian Attention Mechanism.py`
- create `Void Attention Visualizer.py` for heatmap plots of attention including the void token
- include a simple unit test for the visualizer
- update requirements with matplotlib dependency

## Testing
- `python -m py_compile 'Blanchotian Attention Mechanism.py' 'Void Attention Visualizer.py' tests/test_visualizer.py`