### PR TITLE
Add Blanchotian style transfer example

### DIFF
--- a/Blanchotian_Style_Transfer.py
+++ b/Blanchotian_Style_Transfer.py
@@ -1,0 +1,36 @@
+import importlib.machinery
+import importlib.util
+import torch
+
+attn_loader = importlib.machinery.SourceFileLoader('blanchot_attn', 'Blanchotian Attention Mechanism.py')
+attn_spec = importlib.util.spec_from_loader('blanchot_attn', attn_loader)
+attn_mod = importlib.util.module_from_spec(attn_spec)
+attn_loader.exec_module(attn_mod)
+BlanchotianAttention = attn_mod.BlanchotianAttention
+
+xfm_loader = importlib.machinery.SourceFileLoader('blanchot_xfm', 'The Infinite Conversation.py')
+xfm_spec = importlib.util.spec_from_loader('blanchot_xfm', xfm_loader)
+xfm_mod = importlib.util.module_from_spec(xfm_spec)
+xfm_loader.exec_module(xfm_mod)
+BlanchotianTransformer = xfm_mod.BlanchotianTransformer
+
+from BlanchotianEmbedding import BlanchotianEmbedding
+
+def blanchotian_style_transfer(token_ids, vocab_size, style_vector):
+    """Return transformed embeddings influenced by style_vector."""
+    dim = style_vector.shape[-1]
+    embed = BlanchotianEmbedding(vocab_size, dim)
+    model = BlanchotianTransformer(dim=dim, depth=2, heads=4, mlp_dim=dim*2)
+
+    tokens = torch.tensor(token_ids).unsqueeze(0)
+    embeddings = embed(tokens)
+    styled = embeddings + style_vector.view(1,1,-1)
+    out = model(styled)
+    return out.squeeze(0)
+
+if __name__ == '__main__':
+    vocab = 128
+    text = [1,5,9,2,7]
+    style_vec = torch.randn(32)
+    result = blanchotian_style_transfer(text, vocab, style_vec)
+    print(result)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | **Neutral Loss** | Re‑centres error as a creative differential; stable log‑sum‑exp, label smoothing, disaster threshold. | `losses.py` |
 | **Blanchotian Transformer** | Layers commune with **all** preceding layers—an endless palimpsest. | `The Infinite Conversation.py` |
 | **Unavowable Community** | Ensemble whose disagreement is the signal; models converse through divergence. | `Unavowable Community.py` |
+| **Blanchotian Style Transfer** | Apply Blanchotian components to reimagine text in a chosen style. | `Blanchotian_Style_Transfer.py` |
 
 ---
 

--- a/tests/test_style_transfer.py
+++ b/tests/test_style_transfer.py
@@ -1,0 +1,19 @@
+import importlib.machinery
+import importlib.util
+import torch
+
+module_name = 'blanchot_style_transfer'
+file_path = 'Blanchotian_Style_Transfer.py'
+loader = importlib.machinery.SourceFileLoader(module_name, file_path)
+spec = importlib.util.spec_from_loader(module_name, loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+blanchotian_style_transfer = module.blanchotian_style_transfer
+
+
+def test_style_transfer_runs():
+    token_ids = [1, 2, 3]
+    style_vec = torch.randn(32)
+    out = blanchotian_style_transfer(token_ids, vocab_size=50, style_vector=style_vec)
+    assert out.shape[0] == len(token_ids)


### PR DESCRIPTION
## Summary
- add Blanchotian_Style_Transfer module showing how to apply the framework
- document new module in README
- add basic test exercising blanchotian_style_transfer

## Testing
- `python -m pip install pytest` *(fails: Could not find a version that satisfies the requirement)*