### PR TITLE
Remove unused imports from tests

### DIFF
--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,8 +1,6 @@
 import torch
 import pytest
 
-import importlib
-import types
 
 # directly import blanchot_neutral_loss from losses.py
 from losses import blanchot_neutral_loss


### PR DESCRIPTION
## Summary
- fix test suite imports by removing unused modules

## Testing
- `pytest -q` *(fails: command not found)*